### PR TITLE
Resolve #83 autocomplete dla jst w monitoring filter

### DIFF
--- a/feder/monitorings/filters.py
+++ b/feder/monitorings/filters.py
@@ -6,10 +6,22 @@ from django.db.models import Count
 from django.utils.translation import ugettext_lazy as _
 
 from .models import Monitoring
+from teryt_tree.dal_ext.filters import VoivodeshipFilter, CountyFilter, CommunityFilter
 
 
 class MonitoringFilter(django_filters.FilterSet):
     created = django_filters.DateRangeFilter(label=_("Creation date"))
+    voivodeship = VoivodeshipFilter(
+        widget=autocomplete.ModelSelect2(url='teryt:voivodeship-autocomplete')
+    )
+    county = CountyFilter(
+        widget=autocomplete.ModelSelect2(url='teryt:county-autocomplete',
+                                         forward=['voivodeship'])
+    )
+    community = CommunityFilter(
+        widget=autocomplete.ModelSelect2(url='teryt:community-autocomplete',
+                                         forward=['county'])
+    )
 
     def __init__(self, *args, **kwargs):
         super(MonitoringFilter, self).__init__(*args, **kwargs)

--- a/feder/monitorings/models.py
+++ b/feder/monitorings/models.py
@@ -24,6 +24,9 @@ class MonitoringQuerySet(models.QuerySet):
     def with_case_count(self):
         return self.annotate(case_count=models.Count('case'))
 
+    def area(self, jst):
+        return self.filter(case__institution__jst__tree_id=jst.tree_id,
+                           case__institution__jst__lft__range=(jst.lft, jst.rght))
 
 @reversion.register()
 class Monitoring(TimeStampedModel):

--- a/feder/monitorings/tests.py
+++ b/feder/monitorings/tests.py
@@ -3,6 +3,7 @@ from django.core.urlresolvers import reverse
 from django.test import TestCase
 from guardian.shortcuts import assign_perm
 
+from feder.cases.factories import CaseFactory
 from feder.cases.models import Case
 from feder.institutions.factories import InstitutionFactory
 from feder.letters.factories import IncomingLetterFactory
@@ -81,6 +82,12 @@ class MonitoringListViewTestCase(ObjectMixin, PermissionStatusMixin, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self.monitoring)
 
+    def test_filter_by_voivodship(self):
+        self.case = CaseFactory()  # creates a new monitoring (and institution, JST, too)
+
+        response = self.client.get(reverse('monitorings:list') + '?voivodeship=' + unicode(self.case.institution.jst.id))
+        self.assertContains(response, self.case.monitoring)
+        self.assertNotContains(response, self.monitoring)
 
 class MonitoringDetailViewTestCase(ObjectMixin, PermissionStatusMixin, TestCase):
     status_anonymous = 200

--- a/feder/monitorings/tests.py
+++ b/feder/monitorings/tests.py
@@ -85,9 +85,11 @@ class MonitoringListViewTestCase(ObjectMixin, PermissionStatusMixin, TestCase):
     def test_filter_by_voivodship(self):
         self.case = CaseFactory()  # creates a new monitoring (and institution, JST, too)
 
-        response = self.client.get(reverse('monitorings:list') + '?voivodeship={0}'.format(self.case.institution.jst.id))
+        response = self.client.get(reverse('monitorings:list') +
+                                   '?voivodeship={0}'.format(self.case.institution.jst.id))
         self.assertContains(response, self.case.monitoring)
         self.assertNotContains(response, self.monitoring)
+
 
 class MonitoringDetailViewTestCase(ObjectMixin, PermissionStatusMixin, TestCase):
     status_anonymous = 200

--- a/feder/monitorings/tests.py
+++ b/feder/monitorings/tests.py
@@ -85,7 +85,7 @@ class MonitoringListViewTestCase(ObjectMixin, PermissionStatusMixin, TestCase):
     def test_filter_by_voivodship(self):
         self.case = CaseFactory()  # creates a new monitoring (and institution, JST, too)
 
-        response = self.client.get(reverse('monitorings:list') + '?voivodeship=' + unicode(self.case.institution.jst.id))
+        response = self.client.get(reverse('monitorings:list') + '?voivodeship={0}'.format(self.case.institution.jst.id))
         self.assertContains(response, self.case.monitoring)
         self.assertNotContains(response, self.monitoring)
 


### PR DESCRIPTION
interfejs użytkownika z nowym filtrem:
![monitoring-jst-filter](https://user-images.githubusercontent.com/1237985/30700725-b7eafb28-9ee8-11e7-82fb-e9c1a161c27e.png)


SQL:
![monitoring-jst-filter-sql](https://user-images.githubusercontent.com/1237985/30700732-bd96ee06-9ee8-11e7-966f-286f9a022063.png)
