### PR TITLE
Bump version of Django to 2.x

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,7 +1,7 @@
 # Pro-tip: Try not to put anything here. There should be no dependency in
 #	production that isn't in development.
 -r local.txt
-Django==1.11.16  # pyup: <2.0
+Django==2.1.2
 # WSGI Handler
 # ------------------------------------------------
 gevent==1.3.6


### PR DESCRIPTION
I note that the change abandons compatibility for Python 2.7 completely.