### PR TITLE
Removed all warnings in tests.

### DIFF
--- a/feder/letters/models.py
+++ b/feder/letters/models.py
@@ -19,8 +19,7 @@ from feder.institutions.models import Institution
 from feder.records.models import AbstractRecord, Record
 from .utils import email_wrapper, normalize_msg_id, get_body_with_footer
 from ..virus_scan.models import Request as ScanRequest
-from django.utils.timezone import datetime
-from datetime import timedelta
+from django.utils import timezone
 from ..es_search.queries import more_like_this, find_document
 
 logger = logging.getLogger(__name__)
@@ -49,7 +48,7 @@ class LetterQuerySet(models.QuerySet):
         return self.filter(author_user__isnull=True)
 
     def recent(self):
-        return self.filter(created__gt=datetime.now() - timedelta(days=7))
+        return self.filter(created__gt=timezone.now() - timezone.timedelta(days=7))
 
     def with_feed_items(self):
         return (


### PR DESCRIPTION
Removed all warnings in tests.

- Removed .order_by() in  feder/cases/views.py to preserve default ordering, because base View supports pagination and expects queryset to be ordered.
- Changed recent() method in feder/letters/models.py to use Timezone aware timestamp.
