### PR TITLE
Fixed error when saving user permissions

### DIFF
--- a/feder/monitorings/forms.py
+++ b/feder/monitorings/forms.py
@@ -42,7 +42,12 @@ class SelectUserForm(forms.Form):
     )
 
 
+class CheckboxTranslatedUserObjectPermissionsForm(TranslatedUserObjectPermissionsForm):
+    def get_obj_perms_field_widget(self):
+        return forms.CheckboxSelectMultiple
+
+
 class SaveTranslatedUserObjectPermissionsForm(
-    SingleButtonMixin, TranslatedUserObjectPermissionsForm
+    SingleButtonMixin, CheckboxTranslatedUserObjectPermissionsForm
 ):
     pass

--- a/feder/monitorings/tests.py
+++ b/feder/monitorings/tests.py
@@ -5,7 +5,6 @@ from django.core import mail
 from django.urls import reverse
 from django.test import TestCase
 from guardian.shortcuts import assign_perm
-from django.core.management import call_command
 from django.db.models import Count
 from feder.cases.factories import CaseFactory
 from feder.cases.models import Case
@@ -261,6 +260,28 @@ class PermissionWizardTestCase(ObjectMixin, PermissionStatusMixin, TestCase):
         self.client.login(username="john", password="pass")
         response = self.client.get(self.get_url())
         self.assertTemplateUsed(response, "monitorings/permission_wizard.html")
+
+    def test_set_permissions(self):
+        normal_user = UserFactory(username="barney")
+
+        assign_perm("monitorings.manage_perm", self.user, self.monitoring)
+        self.client.login(username="john", password="pass")
+
+        # First step - selecting user to set permissions to
+        data = {
+            "0-user": "{0}".format(normal_user.pk),
+            "permission_wizard-current_step": "0"
+        }
+        response = self.client.post(self.get_url(), data=data)
+        self.assertEqual(response.status_code, 200)
+
+        # Second step - updating user's permissions
+        data = {
+            "1-permissions": ["add_case", "add_draft", "add_letter", "add_monitoring"],
+            "permission_wizard-current_step": "1"
+        }
+        response = self.client.post(self.get_url(), data=data)
+        self.assertEqual(response.status_code, 200)
 
 
 class MonitoringPermissionViewTestCase(ObjectMixin, PermissionStatusMixin, TestCase):

--- a/feder/monitorings/tests.py
+++ b/feder/monitorings/tests.py
@@ -268,10 +268,7 @@ class PermissionWizardTestCase(ObjectMixin, PermissionStatusMixin, TestCase):
         self.client.login(username="john", password="pass")
 
         # First step - selecting user to set permissions to
-        data = {
-            "0-user": normal_user.pk,
-            "permission_wizard-current_step": "0"
-        }
+        data = {"0-user": normal_user.pk, "permission_wizard-current_step": "0"}
         response = self.client.post(self.get_url(), data=data)
         self.assertEqual(response.status_code, 200)
 
@@ -279,14 +276,14 @@ class PermissionWizardTestCase(ObjectMixin, PermissionStatusMixin, TestCase):
         granted_permission = ["add_case", "add_draft", "add_letter"]
         data = {
             "1-permissions": granted_permission,
-            "permission_wizard-current_step": "1"
+            "permission_wizard-current_step": "1",
         }
         response = self.client.post(self.get_url(), data=data)
         self.assertEqual(response.status_code, 302)
         self.assertCountEqual(
-            get_user_perms(normal_user, self.monitoring),
-            granted_permission
+            get_user_perms(normal_user, self.monitoring), granted_permission
         )
+
 
 class MonitoringPermissionViewTestCase(ObjectMixin, PermissionStatusMixin, TestCase):
     permission = ["monitorings.manage_perm"]

--- a/feder/monitorings/views.py
+++ b/feder/monitorings/views.py
@@ -39,6 +39,7 @@ from .forms import (
     MonitoringForm,
     SaveTranslatedUserObjectPermissionsForm,
     SelectUserForm,
+    CheckboxTranslatedUserObjectPermissionsForm,
 )
 from .models import Monitoring
 from .tasks import handle_mass_assign
@@ -184,7 +185,7 @@ class MonitoringDeleteView(
 
 
 class PermissionWizard(LoginRequiredMixin, SessionWizardView):
-    form_list = [SelectUserForm, TranslatedUserObjectPermissionsForm]
+    form_list = [SelectUserForm, CheckboxTranslatedUserObjectPermissionsForm]
     template_name = "monitorings/permission_wizard.html"
 
     def perm_check(self):
@@ -214,8 +215,9 @@ class PermissionWizard(LoginRequiredMixin, SessionWizardView):
         return _("Permissions to {monitoring} updated!").format(monitoring=self.object)
 
     def done(self, form_list, *args, **kwargs):
-        form_list[1].save_obj_perms()
-        self.object = form_list[1].obj
+        form = kwargs["form_dict"]["1"]
+        form.save_obj_perms()
+        self.object = form.obj
         messages.success(self.request, self.get_success_message())
         url = reverse("monitorings:perm", kwargs={"slug": self.object.slug})
         return HttpResponseRedirect(url)

--- a/feder/monitorings/views.py
+++ b/feder/monitorings/views.py
@@ -204,7 +204,7 @@ class PermissionWizard(LoginRequiredMixin, SessionWizardView):
         kw = super().get_form_kwargs(step)
         self.perm_check()
         if step == "1":
-            user_pk = self.storage.get_step_data("0").get("0-user")[0]
+            user_pk = self.storage.get_step_data("0").get("0-user")
             user = get_user_model().objects.get(pk=user_pk)
             kw["user"] = user
             kw["obj"] = self.monitoring
@@ -213,8 +213,8 @@ class PermissionWizard(LoginRequiredMixin, SessionWizardView):
     def get_success_message(self):
         return _("Permissions to {monitoring} updated!").format(monitoring=self.object)
 
-    def done(self, form_list, *args, **kwargs):
-        form = kwargs["form_dict"]["1"]
+    def done(self, form_list, form_dict, *args, **kwargs):
+        form = form_dict["1"]
         form.save_obj_perms()
         self.object = form.obj
         messages.success(self.request, self.get_success_message())

--- a/feder/monitorings/views.py
+++ b/feder/monitorings/views.py
@@ -1,4 +1,3 @@
-from atom.ext.guardian.forms import TranslatedUserObjectPermissionsForm
 from atom.views import DeleteMessageMixin, UpdateMessageMixin
 from braces.views import (
     FormValidMessageMixin,


### PR DESCRIPTION
form_list items are not accessible for some reason - form_list[1] gives "object is unsubscriptable" exception.
But form_dict received via kwargs contains the forms.

Changed user permission widget to checkbox based.