### PR TITLE
Add GitHub Actions and npm in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "extends": [
     "config:base"
   ],
-  "enabledManagers": ["dockerfile", "pip_requirements", "pip_setup"],
+  "enabledManagers": ["dockerfile", "pip_requirements", "pip_setup", "github-actions", "npm"],
   "packageRules": [
     {
       "managers": ["pip_requirements"],


### PR DESCRIPTION
I suggest go away from dependabot ( https://github.com/watchdogpolska/feder/pulls/app%2Fdependabot ) for pull requests, because it does not allow easily rebase pull request manually. Rebase is necessary to successfully return to the old PR and check it against the current project code.