### PR TITLE
Attempt to fix #930

### DIFF
--- a/feder/letters/tests/test_views.py
+++ b/feder/letters/tests/test_views.py
@@ -194,6 +194,13 @@ class LetterDeleteViewTestCase(ObjectMixin, PermissionStatusMixin, TestCase):
         self.client.post(self.get_url())
         self.assertFalse(os.path.isfile(self.from_user.eml.file.name))
 
+    def test_remove_letter_with_attachment(self):
+        self.login_permitted_user()
+        attachment = AttachmentFactory(letter=self.from_user)
+        self.assertTrue(os.path.isfile(attachment.attachment.file.name))
+        self.client.post(self.get_url())
+        self.assertFalse(os.path.isfile(attachment.attachment.file.name))
+
 
 class LetterReplyViewTestCase(ObjectMixin, PermissionStatusMixin, TestCase):
     permission = ["monitorings.reply", "monitorings.add_draft"]

--- a/feder/letters/views.py
+++ b/feder/letters/views.py
@@ -238,12 +238,12 @@ class LetterDeleteView(
     permission_required = "monitorings.delete_letter"
 
     def delete(self, request, *args, **kwargs):
-        result = super().delete(request, *args, **kwargs)
-        for x in self.object.attachment_set.all():
-            x.attachment.delete()  # Delete file
-        self.object.attachment_set.all().delete()  # Delete objects
-        self.object.eml.delete()  # Delete file
-        return result
+        obj = self.get_object()
+        # Manually deleting related files
+        for att_obj in obj.attachment_set.all():
+            att_obj.attachment.delete()
+        obj.eml.delete()
+        return super().delete(request, *args, **kwargs)
 
     def get_success_url(self):
         return self.object.case.get_absolute_url()


### PR DESCRIPTION
Firstly deleting related files, then model instances.

Traceback of previous code error:

```
Traceback (most recent call last):
  File "/opt/feder/releases/releases/20210108122504/env/lib/python3.6/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/opt/feder/releases/releases/20210108122504/env/lib/python3.6/site-packages/django/core/handlers/base.py", line 179, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/feder/releases/releases/20210108122504/env/lib/python3.6/site-packages/django/views/generic/base.py", line 70, in view
    return self.dispatch(request, *args, **kwargs)
  File "/opt/feder/releases/releases/20210108122504/env/lib/python3.6/site-packages/braces/views/_access.py", line 98, in dispatch
    request, *args, **kwargs)
  File "/opt/feder/releases/releases/20210108122504/env/lib/python3.6/site-packages/guardian/mixins.py", line 207, in dispatch
    return super().dispatch(request, *args, **kwargs)
  File "/opt/feder/releases/releases/20210108122504/env/lib/python3.6/site-packages/django/views/generic/base.py", line 98, in dispatch
    return handler(request, *args, **kwargs)
  File "/opt/feder/releases/releases/20210108122504/env/lib/python3.6/site-packages/django/views/generic/edit.py", line 218, in post
    return self.delete(request, *args, **kwargs)
  File "/opt/feder/releases/releases/20210108122504/src/feder/letters/views.py", line 243, in delete
    x.attachment.delete()  # Delete file
  File "/opt/feder/releases/releases/20210108122504/env/lib/python3.6/site-packages/django/db/models/fields/files.py", line 112, in delete
    self.instance.save()
  File "/opt/feder/releases/releases/20210108122504/env/lib/python3.6/site-packages/django/db/models/base.py", line 702, in save
    "unsaved related object '%s'." % field.name

Exception Type: ValueError at /listy/84194/~usun
Exception Value: save() prohibited to prevent data loss due to unsaved related object 'letter'.
```