### PR TITLE
Drop djangorestframework-filters

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -51,7 +51,6 @@ djangorestframework==3.12.4
 djangorestframework-csv==2.1.0
 unicodecsv==0.14.1
 tqdm==4.56.0
-djangorestframework-filters==0.11.1
 django-github-revision==0.0.3
 django-extensions==3.1.0
 django-cleanup==5.2.0


### PR DESCRIPTION
`djangorestframework-filters==0.11.1` was merged into django-filters, so no longer needed. We already migrated to integrated filters. See https://github.com/watchdogpolska/feder/blob/master/config/settings/common.py#L303 and https://django-filter.readthedocs.io/en/stable/guide/rest_framework.html 