### PR TITLE
 Use organisation email in 'From' of email 

### DIFF
--- a/feder/cases/models.py
+++ b/feder/cases/models.py
@@ -1,4 +1,5 @@
 import uuid
+from email.headerregistry import Address
 
 from autoslug.fields import AutoSlugField
 from django.apps import apps
@@ -146,6 +147,14 @@ class Case(TimeStampedModel):
     def update_email(self):
         self.email = settings.CASE_EMAIL_TEMPLATE.format(
             pk=self.pk, domain=self.monitoring.domain.name
+        )
+
+    def get_email_address(self):
+        if not self.monitoring.domain.organisation_id:
+            return Address(addr_spec=self.email)
+        return Address(
+            display_name=self.monitoring.domain.organisation.name,
+            addr_spec=self.email,
         )
 
     @property

--- a/feder/domains/factories.py
+++ b/feder/domains/factories.py
@@ -1,10 +1,11 @@
 import factory
-
+from ..organisations.factories import OrganisationFactory
 from .models import Domain
 
 
 class DomainFactory(factory.django.DjangoModelFactory):
     name = factory.Sequence("case-{}.com".format)
+    organisation = factory.SubFactory(OrganisationFactory)
 
     class Meta:
         model = Domain

--- a/feder/letters/models.py
+++ b/feder/letters/models.py
@@ -258,7 +258,7 @@ class Letter(AbstractRecord):
         html_content, txt_content = self.email_body()
         msg = EmailMultiAlternatives(
             subject=self.case.monitoring.subject,
-            from_email=self.case.email,
+            from_email=str(self.case.get_email_address()),
             reply_to=[self.case.email],
             to=[self.case.institution.email],
             body=txt_content,

--- a/feder/letters/tests/test_views.py
+++ b/feder/letters/tests/test_views.py
@@ -262,6 +262,10 @@ class LetterSendViewTestCase(ObjectMixin, PermissionStatusMixin, TestCase):
         response = self.client.post(self.get_url())
         self.assertEqual(response.status_code, 302)
         self.assertEqual(len(mail.outbox), 1)
+        # reply to email should have organisation name
+        self.assertTrue(
+            self.monitoring.domain.organisation.name in mail.outbox[0].from_email
+        )
 
 
 class LetterRssFeedTestCase(ObjectMixin, PermissionStatusMixin, TestCase):

--- a/feder/monitorings/tests.py
+++ b/feder/monitorings/tests.py
@@ -474,7 +474,17 @@ class MonitoringAssignViewTestCase(ObjectMixin, PermissionStatusMixin, TestCase)
         self.client.post(self.get_url() + "?name=Office", data={"all": "yes"})
         self.send_all_pending()
         self.assertEqual(len(mail.outbox), 2)
-        self.assertTrue(mail.outbox[0].from_email.endswith("custom-domain.com"))
+
+    def test_assign_using_organisation(self):
+        self.monitoring.domain = DomainFactory(organisation__name="angel-corp")
+        self.monitoring.save()
+        self.login_permitted_user()
+        InstitutionFactory(name="Office 1")
+        self.client.post(self.get_url() + "?name=Office", data={"all": "yes"})
+        self.send_all_pending()
+        self.assertEqual(len(mail.outbox), 1)
+        # reply to email should have organisation name
+        self.assertTrue("angel-corp" in mail.outbox[0].from_email)
 
 
 class SitemapTestCase(ObjectMixin, TestCase):


### PR DESCRIPTION
Depends-on: #1047
Close: #1044 

Używam nazwy organizacji w polu 'From' wiadomości e-mail, które są częścią monitoringu 