### PR TITLE
Add feed for monitoring

### DIFF
--- a/feder/letters/tests/test_views.py
+++ b/feder/letters/tests/test_views.py
@@ -268,7 +268,16 @@ class LetterSendViewTestCase(ObjectMixin, PermissionStatusMixin, TestCase):
         )
 
 
-class LetterRssFeedTestCase(ObjectMixin, PermissionStatusMixin, TestCase):
+class LetterFeedTestCaseMixin:
+    def test_simple_render(self):
+        resp = self.client.get(self.get_url())
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, self.letter.title)
+
+
+class LetterRssFeedTestCase(
+    LetterFeedTestCaseMixin, ObjectMixin, PermissionStatusMixin, TestCase
+):
     status_anonymous = 200
     status_no_permission = 200
     permission = []
@@ -277,7 +286,9 @@ class LetterRssFeedTestCase(ObjectMixin, PermissionStatusMixin, TestCase):
         return reverse("letters:rss")
 
 
-class LetterAtomFeedTestCase(ObjectMixin, PermissionStatusMixin, TestCase):
+class LetterAtomFeedTestCase(
+    LetterFeedTestCaseMixin, ObjectMixin, PermissionStatusMixin, TestCase
+):
     status_anonymous = 200
     status_no_permission = 200
     permission = []

--- a/feder/main/templates/base.html
+++ b/feder/main/templates/base.html
@@ -15,6 +15,8 @@
     <![endif]-->
     <link rel="alternate" type="application/rss+xml" title="RSS Feed of letters" href="{% url 'letters:rss' %}"/>
     <link rel="alternate" type="application/atom+xml" title="Atom Feed of letters" href="{% url 'letters:atom' %}"/>
+    <link rel="alternate" type="application/rss+xml" title="RSS Feed of monitorings" href="{% url 'monitorings:rss' %}"/>
+    <link rel="alternate" type="application/atom+xml" title="Atom Feed of monitorings" href="{% url 'monitorings:atom' %}"/>
 
     <!-- favicon -->
     <link rel="apple-touch-icon" sizes="180x180" href="/static/images/favicon/apple-touch-icon.png">

--- a/feder/monitorings/models.py
+++ b/feder/monitorings/models.py
@@ -32,7 +32,7 @@ class MonitoringQuerySet(models.QuerySet):
         )
 
     def with_feed_item(self):
-        return self.select_related('user')
+        return self.select_related("user")
 
     def for_user(self, user):
         return self

--- a/feder/monitorings/models.py
+++ b/feder/monitorings/models.py
@@ -31,6 +31,9 @@ class MonitoringQuerySet(models.QuerySet):
             case__institution__jst__lft__range=(jst.lft, jst.rght),
         )
 
+    def with_feed_item(self):
+        return self.select_related('user')
+
     def for_user(self, user):
         return self
 

--- a/feder/monitorings/tests.py
+++ b/feder/monitorings/tests.py
@@ -689,3 +689,32 @@ class MassMessageViewTestCase(ObjectMixin, PermissionStatusMixin, TestCase):
         self.assertIn(self.case1_tag, recipients_tags)
         self.assertIn(self.case2_tag, recipients_tags)
         self.assertIn(self.global_tag, recipients_tags)
+
+
+class MonitoringFeedTestCaseMixin:
+    def test_simple_render(self):
+        resp = self.client.get(self.get_url())
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, self.monitoring.name)
+
+
+class MonitoringRssFeedTestCase(
+    MonitoringFeedTestCaseMixin, ObjectMixin, PermissionStatusMixin, TestCase
+):
+    status_anonymous = 200
+    status_no_permission = 200
+    permission = []
+
+    def get_url(self):
+        return reverse("monitorings:rss")
+
+
+class MonitoringAtomFeedTestCase(
+    MonitoringFeedTestCaseMixin, ObjectMixin, PermissionStatusMixin, TestCase
+):
+    status_anonymous = 200
+    status_no_permission = 200
+    permission = []
+
+    def get_url(self):
+        return reverse("monitorings:atom")

--- a/feder/monitorings/urls.py
+++ b/feder/monitorings/urls.py
@@ -6,6 +6,8 @@ from . import views
 urlpatterns = [
     url(_(r"^$"), views.MonitoringListView.as_view(), name="list"),
     url(_(r"^~create$"), views.MonitoringCreateView.as_view(), name="create"),
+    url(_(r"^feed$"), views.MonitoringRssFeed(), name="rss"),
+    url(_(r"^feed/atom$"), views.MonitoringAtomFeed(), name="atom"),
     url(
         _(r"^~autocomplete$"),
         views.MonitoringAutocomplete.as_view(),

--- a/feder/monitorings/views.py
+++ b/feder/monitorings/views.py
@@ -534,9 +534,11 @@ class MonitoringRssFeed(Feed):
     feed_url = reverse_lazy("monitorings:rss")
 
     def items(self):
-        return Monitoring.objects.for_user(get_anonymous_user()).with_feed_item().order_by("-created")[
-            :30
-        ]
+        return (
+            Monitoring.objects.for_user(get_anonymous_user())
+            .with_feed_item()
+            .order_by("-created")[:30]
+        )
 
     def item_title(self, item):
         return item.name


### PR DESCRIPTION
We have RSS feed for letters. I would like have RSS feed for monitorings to include new monitorings in periodic bulletin for members.