### PR TITLE
Optimize monitoring list for superuser

### DIFF
--- a/feder/monitorings/models.py
+++ b/feder/monitorings/models.py
@@ -37,6 +37,8 @@ class MonitoringQuerySet(models.QuerySet):
     def for_user(self, user):
         if user.is_anonymous:
             return self.filter(is_public=True)
+        if user.is_superuser:
+            return self
         any_permission = models.Q(monitoringuserobjectpermission__user=user)
         public_only = models.Q(is_public=True)
         return self.filter(any_permission | public_only).distinct()


### PR DESCRIPTION
We might skip filtering (and `SQL JOIN`) for superuser which have - by definition - permission in all monitoring.