### PR TITLE
Add ability to resend outgoing email

### DIFF
--- a/feder/letters/templates/letters/_btn.html
+++ b/feder/letters/templates/letters/_btn.html
@@ -32,8 +32,15 @@
                     {% trans 'Reply' %}
                 </a>
             {% endif %}
-
         {% endif %}
+
+        {% if 'reply' in monitoring_perms and not object.author_institution_id %}
+            <a class="btn btn-primary" href="{% url 'letters:resend' pk=object.pk %}">
+                <i class="fa fa-reply"></i>
+                {% trans 'Resend' %}
+            </a>
+        {% endif %}
+
         {% if not object.is_spam_validated %}
             <a class="btn btn-primary" href="{% url 'letters:spam' pk=object.pk %}">
                 <i class="fa fa-bullhorn"></i>

--- a/feder/letters/templates/letters/letter_resend.html
+++ b/feder/letters/templates/letters/letter_resend.html
@@ -1,0 +1,27 @@
+{% extends 'letters/base_object.html' %}
+
+{% load i18n %}
+
+{% block meta %}
+    <meta name="robots" content="noindex">
+{% endblock %}
+
+{% block breadcrumb_row %}
+    <li
+        itemprop="itemListElement"
+        itemscope
+        itemtype="http://schema.org/ListItem"
+        class="active">
+        <span itmeprop="name">{% trans 'Resend letter' %}</span>
+    </li>
+{% endblock %}
+
+{% block content_object %}
+    {% blocktrans with object=object %}Are you sure you want to resend letter "{{ object }}"?{% endblocktrans %}
+    <form method="POST">
+        <div style="display:none">
+            <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
+        </div>
+     <input type="submit" class="btn btn-primary" name="spam" value="Resend letter">
+    </form>
+{% endblock %}

--- a/feder/letters/urls.py
+++ b/feder/letters/urls.py
@@ -59,6 +59,9 @@ urlpatterns = [
         _(r"^(?P<pk>[\d-]+)/~delete$"), views.LetterDeleteView.as_view(), name="delete"
     ),
     url(_(r"^(?P<pk>[\d-]+)/~reply$"), views.LetterReplyView.as_view(), name="reply"),
+    url(
+        _(r"^(?P<pk>[\d-]+)/~resend$"), views.LetterResendView.as_view(), name="resend"
+    ),
     url(_(r"^(?P<pk>[\d-]+)/~spam"), views.LetterReportSpamView.as_view(), name="spam"),
     url(
         _(r"^(?P<pk>[\d-]+)/~mark-spam"),


### PR DESCRIPTION
Pan Krzysztof Wychowałek wysłał monitoring. Część wiadomości nie dotarła. Przygotował aktualne adresy e-mail. Chciałby ponownie wysłać wnioski, ale system nie oferuje wprost takiej możliwości.

@KatarzynaBatko kombinuje w takich sytuacjach z odpowiadaniem na nasze wiadomości, albo wysyłką poza ePUAP-em, co nie wydaje się zbyt efektywne.